### PR TITLE
fix: correct spelling in `autocmds` configuration

### DIFF
--- a/.config/nvim/lua/core/autocmds.lua
+++ b/.config/nvim/lua/core/autocmds.lua
@@ -29,11 +29,11 @@ autocmd('BufEnter', {
   command = 'set fo-=c fo-=r fo-=o'
 })
 
--- Settings for fyletypes:
--- Disable line lenght marker
-augroup('setLineLenght', { clear = true })
+-- Settings for filetypes:
+-- Disable line length marker
+augroup('setLineLength', { clear = true })
 autocmd('Filetype', {
-  group = 'setLineLenght',
+  group = 'setLineLength',
   pattern = { 'text', 'markdown', 'html', 'xhtml', 'javascript', 'typescript' },
   command = 'setlocal cc=0'
 })


### PR DESCRIPTION
Given how professional the rest of your configuration is, I assume these are typos. However, if you purposefully misspelled these words, disregard this PR.

`y` instead of `i` seems plausible given the proximity on a qwerty keyboard.

:^)